### PR TITLE
Fix DigitalOcean Style Guide Link

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -62,7 +62,7 @@ A Youtube video aimed at academics, but very generally applicable writing advice
 
 ## Style Guides
 
-### [The DigitalOcean Style Guide](do.co/style)
+### [The DigitalOcean Style Guide](https://do.co/style)
 Used for all tutorials on the DigitalOcean community, this style guide is opinionated but a good starting point for writing tutorials that are widely accessible and engaging.
 
 ## Courses 


### PR DESCRIPTION
The current link has no protocol specified, so it just links internally into this repository instead of navigating to the actual guide.